### PR TITLE
Remove return type from sort() function

### DIFF
--- a/tests/tr-sort.cpp
+++ b/tests/tr-sort.cpp
@@ -27,7 +27,7 @@ TEMPLATE_TEST_CASE(
         std::vector<TestType> tr_sorted_data = unsorted_data;
         std::vector<TestType> stable_sorted_data = unsorted_data;
         // sort with tr-sort and stdlib stable_sort
-        REQUIRE(tr_sort::sort<TestType>({tr_sorted_data}));
+        tr_sort::sort<TestType>({tr_sorted_data});
         // stable_sort returns void so no need to test return value
         std::stable_sort(stable_sorted_data.begin(), stable_sorted_data.end());
         // verify both sorted arrays are equal
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE(
         std::vector<TestType> tr_sorted_data = unsorted_data;
         std::vector<TestType> stable_sorted_data = unsorted_data;
         // sort with tr-sort and stdlib stable_sort
-        REQUIRE(tr_sort::sort<TestType>({tr_sorted_data}));
+        tr_sort::sort<TestType>({tr_sorted_data});
         // stable_sort returns void so no need to test return value
         std::stable_sort(stable_sorted_data.begin(), stable_sorted_data.end());
         // results should be the same

--- a/tr-sort/include/tr-sort.hpp
+++ b/tr-sort/include/tr-sort.hpp
@@ -32,8 +32,6 @@ namespace com::saxbophone::tr_sort {
      * @tparam Extent size of iterable (leave default for dynamic size)
      * @tparam Real data type used by the algorithm for real numbers
      * @param[out] data iterable to sort
-     * @returns `true` when the sort was successful
-     * @returns `false` when the sort was unsuccessful
      * @todo Add template param or function param for conversion lambda function
      * to be used for casting objects of type T to some other Scalar type. This
      * may or may not need an additional template type param to determine which
@@ -47,10 +45,10 @@ namespace com::saxbophone::tr_sort {
         std::size_t Extent = std::dynamic_extent,
         typename Real = long double
     >
-    bool sort(std::span<T, Extent> data) {
+    void sort(std::span<T, Extent> data) {
         // don't sort data of length {0..1}
         if (data.size() < 2) {
-            return true;
+            return;
         }
         // gather stats on first pass of data
         std::size_t size = data.size();
@@ -89,7 +87,7 @@ namespace com::saxbophone::tr_sort {
         }
         // short cut for already sorted
         if (already_sorted) {
-            return true;
+            return;
         }
         // short cut for size 2
         if (data.size() == 2) {
@@ -142,7 +140,7 @@ namespace com::saxbophone::tr_sort {
                 i++;
             }
         }
-        return true;
+        return;
     }
 }
 


### PR DESCRIPTION
Contrary to how the algorithm was initially expected to develop, there is no built-in detection of sort success or failure (there's currently no way to determine sort failure within the algo itself)