### PR TITLE
Wrote special test cases for arrays of size 2

### DIFF
--- a/tests/tr-sort.cpp
+++ b/tests/tr-sort.cpp
@@ -38,6 +38,28 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
+    "tr_sort::sort() does a stable sort on input arrays of size 2", "",
+    std::uint8_t, std::int8_t, std::uint16_t, std::int16_t, std::uint32_t,
+    std::int32_t, std::uint64_t, std::int64_t, float, double, long double
+) {
+    for (int i = 0; i < 1000; i++) {
+        // PARAM: SIZE (100)
+        std::vector<TestType> unsorted_data = prng.generate<TestType>(2);
+        // create two copies to work-in-place
+        std::vector<TestType> tr_sorted_data = unsorted_data;
+        std::vector<TestType> stable_sorted_data = unsorted_data;
+        // sort with tr-sort and stdlib stable_sort
+        tr_sort::sort<TestType>({tr_sorted_data});
+        // stable_sort returns void so no need to test return value
+        std::stable_sort(stable_sorted_data.begin(), stable_sorted_data.end());
+        // verify both sorted arrays are equal
+        bool equal = tr_sorted_data == stable_sorted_data;
+        // REQUIRE(tr_sorted_data == stable_sorted_data);
+        REQUIRE(equal);
+    }
+}
+
+TEMPLATE_TEST_CASE(
     "tr_sort::sort() does a stable sort on input arrays containing only extreme finite values and infinities", "",
     float, double, long double
 ) {

--- a/tests/tr-sort.cpp
+++ b/tests/tr-sort.cpp
@@ -71,7 +71,7 @@ TEMPLATE_TEST_CASE(
         -std::numeric_limits<TestType>::infinity(),
         +std::numeric_limits<TestType>::infinity()
     };
-    std::size_t array_size = 10;
+    std::size_t array_size = GENERATE(2u, 10u);
     std::random_device rd;
     std::default_random_engine engine(rd());
     std::uniform_int_distribution<std::size_t> picker(0, 3);

--- a/tr-sort/include/tr-sort.hpp
+++ b/tr-sort/include/tr-sort.hpp
@@ -93,6 +93,7 @@ namespace com::saxbophone::tr_sort {
         if (data.size() == 2) {
             data[0] = min;
             data[data.size() - 1] = max;
+            return;
         }
         if constexpr (std::is_floating_point<T>::value) {
             if (min == -std::numeric_limits<T>::infinity()) {


### PR DESCRIPTION
Rationale: I believe there is a typo in the current tr-sort code, which almost optimises for these cases (since we can just check which is the biggest and which is the smallest then call it a day), but where an early return has been missed out. These additional test cases are to confirm 2-sized arrays are being correctly sorted both before correcting the typo AND after